### PR TITLE
use CO API token cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,20 +5,20 @@
     "require": {
         "php": ">=8.2",
         "ext-json": "*",
-        "dbp/campusonline-api": "^0.3.44",
+        "dbp/campusonline-api": "^0.3.45",
         "dbp/relay-base-course-bundle": "^0.2.20",
         "dbp/relay-core-bundle": "^0.1.228",
         "doctrine/dbal": "^4.2",
         "doctrine/doctrine-migrations-bundle": "^3.4",
         "doctrine/migrations": "^3.9",
         "doctrine/orm": "^3.4",
-        "symfony/event-dispatcher": "^6.4 || ^7.4",
-        "symfony/http-kernel": "^6.4 || ^7.4",
-        "symfony/http-foundation": "^6.4 || ^7.4",
-        "symfony/dependency-injection": "^6.4 || ^7.4",
+        "psr/log": "^1.1.4 || ^2.0 || ^3.0",
         "symfony/config": "^6.4 || ^7.4",
+        "symfony/dependency-injection": "^6.4 || ^7.4",
+        "symfony/event-dispatcher": "^6.4 || ^7.4",
         "symfony/framework-bundle": "^6.4 || ^7.4",
-        "psr/log": "^1.1.4 || ^2.0 || ^3.0"
+        "symfony/http-foundation": "^6.4 || ^7.4",
+        "symfony/http-kernel": "^6.4 || ^7.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.50",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12fcb1f9f4386be55d40e97ea5172d5f",
+    "content-hash": "b580985993890a1a2dbf2fc2405999c4",
     "packages": [
         {
             "name": "api-platform/documentation",
@@ -984,16 +984,16 @@
         },
         {
             "name": "dbp/campusonline-api",
-            "version": "v0.3.44",
+            "version": "v0.3.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/digital-blueprint/campusonline-api.git",
-                "reference": "91555cdbb776027f775c30f032c29711a526e536"
+                "reference": "eae021b31e5b9a16075366033cd70fec08fc8edd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/digital-blueprint/campusonline-api/zipball/91555cdbb776027f775c30f032c29711a526e536",
-                "reference": "91555cdbb776027f775c30f032c29711a526e536",
+                "url": "https://api.github.com/repos/digital-blueprint/campusonline-api/zipball/eae021b31e5b9a16075366033cd70fec08fc8edd",
+                "reference": "eae021b31e5b9a16075366033cd70fec08fc8edd",
                 "shasum": ""
             },
             "require": {
@@ -1028,9 +1028,9 @@
             ],
             "support": {
                 "issues": "https://github.com/digital-blueprint/campusonline-api/issues",
-                "source": "https://github.com/digital-blueprint/campusonline-api/tree/v0.3.44"
+                "source": "https://github.com/digital-blueprint/campusonline-api/tree/v0.3.45"
             },
-            "time": "2026-06-10T07:21:55+00:00"
+            "time": "2026-06-15T07:54:28+00:00"
         },
         {
             "name": "dbp/relay-base-course-bundle",
@@ -2385,16 +2385,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.1",
+            "version": "7.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
+                "reference": "bf5f35ad4b774b9d7c5766c02035e865e7e3fdab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
-                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/bf5f35ad4b774b9d7c5766c02035e865e7e3fdab",
+                "reference": "bf5f35ad4b774b9d7c5766c02035e865e7e3fdab",
                 "shasum": ""
             },
             "require": {
@@ -2493,7 +2493,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.2"
             },
             "funding": [
                 {
@@ -2509,7 +2509,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-07T22:54:06+00:00"
+            "time": "2026-06-12T21:49:57+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -2597,16 +2597,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "640e2897bbee822dbc8af761d49e1a29b1f2a6b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/640e2897bbee822dbc8af761d49e1a29b1f2a6b1",
+                "reference": "640e2897bbee822dbc8af761d49e1a29b1f2a6b1",
                 "shasum": ""
             },
             "require": {
@@ -2696,7 +2696,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.1"
             },
             "funding": [
                 {
@@ -2712,7 +2712,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-06-12T21:50:12+00:00"
         },
         {
             "name": "kekos/multipart-form-data-parser",

--- a/src/Service/CourseProvider.php
+++ b/src/Service/CourseProvider.php
@@ -48,6 +48,8 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 class CourseProvider implements CourseProviderInterface, LoggerAwareInterface
 {
@@ -59,7 +61,7 @@ class CourseProvider implements CourseProviderInterface, LoggerAwareInterface
     private array $config = [];
     private ?CacheItemPoolInterface $cachePool = null;
     private int $cacheTTL = 0;
-
+    private ?CacheItemPoolInterface $campusonlineApiCacheItemPool = null;
     /**
      * @var string[]
      */
@@ -161,6 +163,16 @@ class CourseProvider implements CourseProviderInterface, LoggerAwareInterface
         $this->config = $config;
         $this->eventTimeZone = new \DateTimeZone(
             $this->config[Configuration::CAMPUS_ONLINE_NODE][Configuration::EVENT_TIME_ZONE_NODE]);
+    }
+
+    #[Required]
+    public function setCampusonlineApiCacheItemPool(?CacheItemPoolInterface $coCacheItemPool): void
+    {
+        if ($coCacheItemPool instanceof NamespacedPoolInterface) {
+            $coCacheItemPool = $coCacheItemPool->withSubNamespace(Connection::CACHE_SUBNAMESPACE);
+        }
+
+        $this->campusonlineApiCacheItemPool = $coCacheItemPool;
     }
 
     private function getEventTimeZone(): \DateTimeZone
@@ -663,13 +675,14 @@ class CourseProvider implements CourseProviderInterface, LoggerAwareInterface
     private function getCourseApi(): CourseApi
     {
         if ($this->courseApi === null) {
-            $this->courseApi = new CourseApi(
-                new Connection(
-                    $this->config[Configuration::CAMPUS_ONLINE_NODE][Configuration::BASE_URL_NODE] ?? '',
-                    $this->config[Configuration::CAMPUS_ONLINE_NODE][Configuration::CLIENT_ID_NODE] ?? '',
-                    $this->config[Configuration::CAMPUS_ONLINE_NODE][Configuration::CLIENT_SECRET_NODE] ?? ''
-                )
+            $connection = new Connection(
+                $this->config[Configuration::CAMPUS_ONLINE_NODE][Configuration::BASE_URL_NODE] ?? '',
+                $this->config[Configuration::CAMPUS_ONLINE_NODE][Configuration::CLIENT_ID_NODE] ?? '',
+                $this->config[Configuration::CAMPUS_ONLINE_NODE][Configuration::CLIENT_SECRET_NODE] ?? ''
             );
+            $connection->setCache($this->campusonlineApiCacheItemPool);
+
+            $this->courseApi = new CourseApi($connection);
             $this->courseApi->setLogger($this->logger);
         }
 

--- a/src/Service/CourseProvider.php
+++ b/src/Service/CourseProvider.php
@@ -59,8 +59,6 @@ class CourseProvider implements CourseProviderInterface, LoggerAwareInterface
 
     private ?CourseApi $courseApi = null;
     private array $config = [];
-    private ?CacheItemPoolInterface $cachePool = null;
-    private int $cacheTTL = 0;
     private ?CacheItemPoolInterface $campusonlineApiCacheItemPool = null;
     /**
      * @var string[]
@@ -173,6 +171,7 @@ class CourseProvider implements CourseProviderInterface, LoggerAwareInterface
         }
 
         $this->campusonlineApiCacheItemPool = $coCacheItemPool;
+        $this->courseApi?->getConnection()->setCache($coCacheItemPool);
     }
 
     private function getEventTimeZone(): \DateTimeZone

--- a/tests/Service/CourseProviderTest.php
+++ b/tests/Service/CourseProviderTest.php
@@ -25,6 +25,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class CourseProviderTest extends ApiTestCase
@@ -1771,6 +1772,28 @@ class CourseProviderTest extends ApiTestCase
         $this->assertEquals(new \DateTimeImmutable('2026-03-11T10:15:00', new \DateTimeZone('Europe/Vienna')), $courseEvent->getStartAt());
         $this->assertEquals(new \DateTimeImmutable('2026-03-11T11:45:00', new \DateTimeZone('Europe/Vienna')), $courseEvent->getEndAt());
         $this->assertSame('CLASS', $courseEvent->getTypeKey());
+    }
+
+    public function testCampusononlineApiTokenCache(): void
+    {
+        $this->courseProvider->setCampusonlineApiCacheItemPool(new ArrayAdapter());
+
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json;charset=utf-8'],
+                file_get_contents(__DIR__.'/appointment_api_item_response.json')),
+        ]);
+        $courseEvent = $this->courseProvider->getCourseEventById('1');
+        $this->assertSame('1', $courseEvent->getIdentifier());
+
+        $this->courseProvider->reset(); // reset request (in-memory) cache
+
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json;charset=utf-8'],
+                file_get_contents(__DIR__.'/appointment_api_item_response.json')),
+        ], mockAuthServerResponses: false
+        );
+        $courseEvent = $this->courseProvider->getCourseEventById('1');
+        $this->assertSame('1', $courseEvent->getIdentifier());
     }
 
     public function testGetCourseEventByIdentifierNotFound(): void


### PR DESCRIPTION
This PR updates the campusonline-course-connector to use the token cache support introduced in `dbp/campusonline-api v0.3.45`

**changes**:
* Require `dbp/campusonline-api ^0.3.45`
* Inject a separate campusonline API cache pool into `CourseProvider`
* Scope the token cache with `Connection::CACHE_SUBNAMESPACE`
* Pass the cache to `PublicRestApi\Connection::setCache(...)` before creating the `CourseApi`

**how to verify:**
* `composer phpstan`
* `composer test`
* `composer cs`
